### PR TITLE
feat: morpho example supplying/repaying from rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,34 @@ are effectively MEV, you can do some really interesting things with them. Like
 - Impress your friends
 - And more!
 
-[MevWallet]: https://github.com/blunt-instruments/MevWallet
-[Signet Orders]: https://signet.sh/docs/learn-about-signet/cross-chain-transfers/
+## App Examples
 
-## Main Examples
+- [`Morpho.sol`](./src/examples/Morpho.sol) - Contracts that allow you to drive
+  Morpho lending market positions using Signet Orders. This allows you to
+  supply, borrow, and lend Morpho positions on Ethereum from Signet instantly
+  and atomically.
+
+## Orders Examples
 
 - [`SignetStd.sol`](./src/SignetStd.sol) - A simple contract that
   auto-configures Signet system parameters, based on the chain id.
 - [`Flash.sol`](./src/examples/Flash.sol) - Allows your contract to flash borrow
-  any asset (provided some searcher will provide it). Flash loans work by having an input and output of the same asset. The Output is then used as the Input to its own Order. This is pretty neat 🎀
+  any asset (provided some searcher will provide it). Flash loans work by
+  having an input and output of the same asset. The Output is then used as the
+  Input to its own Order. This is pretty neat 🎀
 - [`GetOut.sol`](./src/examples/GetOut.sol) - A shortcut contract for
   exiting Signet (by offering searchers a 50 bps fee).
 - [`PayMe.sol`](./src/examples/PayMe.sol) - Payment gating for smart contracts,
-  using a Signet Order with no inputs. These ensures that contract execution is invalid unless SOMEONE has filled the Order. Unlike traditional payment gates that check `msg.value`, this does NOT require the calling contract to manage cash flow. Instead _any third party_ can fill the order. The calling contract can be blind to the payment. This greatly simplifies contract logic required
+  using a Signet Order with no inputs. These ensures that contract execution is
+  invalid unless SOMEONE has filled the Order. Unlike traditional payment gates
+  that check `msg.value`, this does NOT require the calling contract to manage
+  cash flow. Instead _any third party_ can fill the order. The calling contract
+  can be blind to the payment. This greatly simplifies contract logic required
   to implement payment gates.
 - [`PayYou.sol`](./src/examples/PayYou.sol) - The opposite of payment gating,
-  this allows a contract to generate MEV by offering a Signet Order with no outputs. This payment becomes a bounty for calling the contract, and functions as an incentivized scheduling system.
+  this allows a contract to generate MEV by offering a Signet Order with no
+  outputs. This payment becomes a bounty for calling the contract, and
+  functions as an incentivized scheduling system.
 
 ## Basic Repo Instructions
 
@@ -50,3 +62,6 @@ $ forge test
 ```shell
 $ forge fmt
 ```
+
+[MevWallet]: https://github.com/blunt-instruments/MevWallet
+[Signet Orders]: https://signet.sh/docs/learn-about-signet/cross-chain-transfers/

--- a/src/apps/Morpho.sol
+++ b/src/apps/Morpho.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IMorpho, MarketParams} from "../interfaces/IMorpho.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SignetStd} from "../SignetStd.sol";
+import {RollupOrders} from "zenith/src/orders/RollupOrders.sol";
+
+// Rollup contract that uses a host chain Morpho shortcut to supply collateral
+// and repay loans on behalf of the rollup user.
+contract UseMorpho is SignetStd {
+    address immutable shortcut;
+
+    address immutable hostLoanToken;
+    address immutable hostCollateralToken;
+
+    IERC20 immutable loanToken;
+    IERC20 immutable collateralToken;
+
+    constructor(address _shortcut, address _hostLoan, address _hostCollateral) SignetStd() {
+        shortcut = _shortcut;
+        hostLoanToken = _hostLoan;
+        hostCollateralToken = _hostCollateral;
+
+        if (_hostLoan == HOST_WETH) {
+            loanToken = WETH;
+        } else if (_hostLoan == HOST_WBTC) {
+            loanToken = WBTC;
+        } else if (_hostLoan == HOST_USDC || _hostLoan == HOST_USDT) {
+            loanToken = WUSD;
+        } else {
+            revert("Unsupported loan token");
+        }
+
+        loanToken.approve(address(ORDERS), type(uint256).max);
+        collateralToken.approve(address(ORDERS), type(uint256).max);
+    }
+
+    function supply(uint256 amount) external {
+        if (amount > 0) {
+            collateralToken.transferFrom(msg.sender, address(this), amount);
+        }
+
+        // the amount is whatever our current balance is
+        amount = collateralToken.balanceOf(address(this));
+
+        RollupOrders.Input[] memory inputs = new RollupOrders.Input[](1);
+        inputs[0] = makeInput(address(collateralToken), amount);
+
+        // The output pays the collateral token to the shortcut,
+        // Then calls the shortcut to supply the collateral.
+        RollupOrders.Output[] memory outputs = new RollupOrders.Output[](2);
+        outputs[0] = makeHostOutput(address(hostCollateralToken), amount, shortcut);
+        // call shortcut
+        outputs[1] = makeHostOutput(shortcut, 0, address(this));
+
+        ORDERS.initiate(
+            block.timestamp, // no deadline
+            inputs,
+            outputs
+        );
+    }
+
+    function repay(uint256 amount) external {
+        if (amount > 0) {
+            loanToken.transferFrom(msg.sender, address(this), amount);
+        }
+
+        // the amount is whatever our current balance is
+        amount = loanToken.balanceOf(address(this));
+
+        RollupOrders.Input[] memory inputs = new RollupOrders.Input[](1);
+        inputs[0] = makeInput(address(loanToken), amount);
+
+        // The output pays the loan token to the shortcut,
+        // Then calls the shortcut to repay the loan.
+        RollupOrders.Output[] memory outputs = new RollupOrders.Output[](2);
+        outputs[0] = makeHostOutput(address(hostLoanToken), amount, shortcut);
+        outputs[1] = makeHostOutput(shortcut, 0, address(this)); // call shortcut
+
+        ORDERS.initiate(
+            block.timestamp, // no deadline
+            inputs,
+            outputs
+        );
+    }
+}
+
+// This contract should be deployed on the host chain. It is used as a shortcut
+// to supply collateral to Morpho and can be invoked by the rollup via an Order.
+contract HostMorphoShortcut {
+    IMorpho immutable morpho;
+
+    // This is an unrolled MarketParams struct.
+    IERC20 immutable loanToken;
+    IERC20 immutable collateralToken;
+    address immutable oracle;
+    address immutable irm;
+    uint256 immutable lltv;
+
+    address immutable onBehalf;
+
+    constructor(IMorpho _morpho, MarketParams memory _params, address _onBehalf) {
+        morpho = _morpho;
+
+        loanToken = IERC20(_params.loanToken);
+        collateralToken = IERC20(_params.collateralToken);
+        oracle = _params.oracle;
+        irm = _params.irm;
+        lltv = _params.lltv;
+
+        onBehalf = _onBehalf;
+
+        collateralToken.approve(address(_morpho), type(uint256).max);
+    }
+
+    fallback() external {
+        MarketParams memory params;
+        params.loanToken = address(loanToken);
+        params.collateralToken = address(collateralToken);
+        params.oracle = oracle;
+        params.irm = irm;
+        params.lltv = lltv;
+
+        uint256 loanTokenBalance = loanToken.balanceOf(address(this));
+        uint256 collateralTokenBalance = collateralToken.balanceOf(address(this));
+
+        // If we have loan tokens, we are repaying a loan.
+        if (loanTokenBalance > 0) {
+            morpho.repay(params, loanTokenBalance, 0, onBehalf, "");
+            return;
+        }
+
+        // If we have collateral tokens, we are supplying collateral.
+        if (collateralTokenBalance > 0) {
+            morpho.supplyCollateral(params, collateralTokenBalance, onBehalf, "");
+
+            // borrow and send to rollup?
+
+            return;
+        }
+
+        revert("No tokens received");
+    }
+}

--- a/src/apps/Morpho.sol
+++ b/src/apps/Morpho.sol
@@ -6,10 +6,41 @@ import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SignetStd} from "../SignetStd.sol";
 import {RollupOrders} from "zenith/src/orders/RollupOrders.sol";
 
-// Rollup contract that uses a host chain Morpho shortcut to supply collateral
-// and repay loans on behalf of the rollup user.
+// How this works:
+// - The Signet Orders system calls `transferFrom` and check for the presence
+//   of a `Fill` event.
+// - The MorphoShortcut contract implements `transferFrom` to run
+//   supply/repay logic on a specific Morpho Market.
+// - The rollup contract uses Orders to send tokens to the shortcut
+//   and then call the shortcut to perform the action.
+// - This all occurs in the same block.
+
+// The rollup order is structured as follows:
+// - Input: X token on rollup chain.
+// - Output: transfer X token on host chain to shortcut.
+// - Output: invoke host chain shortcut contract.
+//
+// The Signet STF logic ensures that the Input is not delivered unless the
+// outputs are succesful.
+
+// Note:
+// We've provided a rollup contract for the example, but this could also be
+// initiated via a signed order from an EOA. No contract is needed. Both
+// contracts and EOAs can use the Morpho shortcut to interact with Morpho from
+// Signet.
+
+// Note:
+// The example order has no spread. Real orders can have a spread, and can also
+// have their inputs in ANY asset. I.e. the user can use rollup ETH to pay for
+// USDC collateral or repay a WBTC loan on the host Morpho market. This is
+// pretty neat.
+
+// The Rollup contract creates orders to interact with Morpho on host net via
+// the shortcut.
 contract UseMorpho is SignetStd {
-    address immutable shortcut;
+    /// @dev Address of the shortcut on the host chain.
+    address immutable repayShortcut;
+    address immutable supplyShortcut;
 
     address immutable hostLoanToken;
     address immutable hostCollateralToken;
@@ -18,10 +49,12 @@ contract UseMorpho is SignetStd {
     IERC20 immutable collateralToken;
 
     constructor(address _shortcut, address _hostLoan, address _hostCollateral) SignetStd() {
+        // The address of the shortcut contract should be well-known.
         shortcut = _shortcut;
+
+        // Autodetect rollup tokens based on token addresses on host network.
         hostLoanToken = _hostLoan;
         hostCollateralToken = _hostCollateral;
-
         if (_hostLoan == HOST_WETH) {
             loanToken = WETH;
         } else if (_hostLoan == HOST_WBTC) {
@@ -32,11 +65,12 @@ contract UseMorpho is SignetStd {
             revert("Unsupported loan token");
         }
 
+        // Pre-emptively approve the Orders contract to spend our tokens.
         loanToken.approve(address(ORDERS), type(uint256).max);
         collateralToken.approve(address(ORDERS), type(uint256).max);
     }
 
-    function supply(uint256 amount) external {
+    function supply(address onBehalf, uint256 amount) external {
         if (amount > 0) {
             collateralToken.transferFrom(msg.sender, address(this), amount);
         }
@@ -47,12 +81,11 @@ contract UseMorpho is SignetStd {
         RollupOrders.Input[] memory inputs = new RollupOrders.Input[](1);
         inputs[0] = makeInput(address(collateralToken), amount);
 
-        // The output pays the collateral token to the shortcut,
-        // Then calls the shortcut to supply the collateral.
+        // The first output pays the collateral token to the shortcut.
+        // The second output calls the shortcut to supply the collateral.
         RollupOrders.Output[] memory outputs = new RollupOrders.Output[](2);
-        outputs[0] = makeHostOutput(address(hostCollateralToken), amount, shortcut);
-        // call shortcut
-        outputs[1] = makeHostOutput(shortcut, 0, address(this));
+        outputs[0] = makeHostOutput(address(hostCollateralToken), amount, supplyShortcut);
+        outputs[1] = makeHostOutput(supplyShortcut, amount, onBehalf);
 
         ORDERS.initiate(
             block.timestamp, // no deadline
@@ -61,22 +94,22 @@ contract UseMorpho is SignetStd {
         );
     }
 
-    function repay(uint256 amount) external {
+    function repay(address onBehalf, uint256 amount) external {
         if (amount > 0) {
             loanToken.transferFrom(msg.sender, address(this), amount);
         }
 
-        // the amount is whatever our current balance is
+        // Send all tokens.
         amount = loanToken.balanceOf(address(this));
 
         RollupOrders.Input[] memory inputs = new RollupOrders.Input[](1);
         inputs[0] = makeInput(address(loanToken), amount);
 
-        // The output pays the loan token to the shortcut,
-        // Then calls the shortcut to repay the loan.
+        // The first output pays the loan token to the shortcut.
+        // The second output calls the shortcut to repay the loan.
         RollupOrders.Output[] memory outputs = new RollupOrders.Output[](2);
-        outputs[0] = makeHostOutput(address(hostLoanToken), amount, shortcut);
-        outputs[1] = makeHostOutput(shortcut, 0, address(this)); // call shortcut
+        outputs[0] = makeHostOutput(address(hostLoanToken), amount, repayShortcut);
+        outputs[1] = makeHostOutput(repayShortcut, amount, onBehalf);
 
         ORDERS.initiate(
             block.timestamp, // no deadline
@@ -86,21 +119,20 @@ contract UseMorpho is SignetStd {
     }
 }
 
-// This contract should be deployed on the host chain. It is used as a shortcut
-// to supply collateral to Morpho and can be invoked by the rollup via an Order.
-contract HostMorphoShortcut {
+abstract contract HostMorphoUser {
     IMorpho immutable morpho;
 
     // This is an unrolled MarketParams struct.
     IERC20 immutable loanToken;
     IERC20 immutable collateralToken;
+
     address immutable oracle;
     address immutable irm;
     uint256 immutable lltv;
 
-    address immutable onBehalf;
+    error InsufficentTokensReceived(uint256 received, uint256 required);
 
-    constructor(IMorpho _morpho, MarketParams memory _params, address _onBehalf) {
+    constructor(IMorpho _morpho, MarketParams memory _params) {
         morpho = _morpho;
 
         loanToken = IERC20(_params.loanToken);
@@ -109,37 +141,56 @@ contract HostMorphoShortcut {
         irm = _params.irm;
         lltv = _params.lltv;
 
-        onBehalf = _onBehalf;
-
+        loanToken.approve(address(_morpho), type(uint256).max);
         collateralToken.approve(address(_morpho), type(uint256).max);
     }
 
-    fallback() external {
-        MarketParams memory params;
+    function checkReceived(uint256 received, uint256 required) internal pure {
+        if (received < required) {
+            revert InsufficentTokensReceived(received, required);
+        }
+    }
+
+    function loadParams() internal view returns (MarketParams memory params) {
         params.loanToken = address(loanToken);
         params.collateralToken = address(collateralToken);
         params.oracle = oracle;
         params.irm = irm;
         params.lltv = lltv;
+    }
+}
 
+// This contract should be deployed on the host chain. It is used as a shortcut
+// to supply collateral to Morpho and can be invoked by the rollup via an Order.
+contract HostMorphoRepay is HostMorphoUser {
+    constructor(IMorpho _morpho, MarketParams memory _params) HostMorphoUser(_morpho, _params) {}
+
+    /// Uses the ERC20 transferFrom interface to invoke contract logic. This
+    /// allows us to invoke logic from the Orders contract
+    function transferFrom(address, address recipient, uint256 amount) external returns (bool) {
         uint256 loanTokenBalance = loanToken.balanceOf(address(this));
+        checkReceived(loanTokenBalance, amount);
+        morpho.repay(loadParams(), loanTokenBalance, 0, recipient, "");
+        return true;
+    }
+}
+
+contract HostMorphoSupply is HostMorphoUser {
+    constructor(IMorpho _morpho, MarketParams memory _params) HostMorphoUser(_morpho, _params) {}
+
+    /// Uses the ERC20 transferFrom interface to invoke contract logic. This
+    /// allows us to invoke logic from the Orders contract
+    function transferFrom(address, address recipient, uint256 amount) external returns (bool) {
         uint256 collateralTokenBalance = collateralToken.balanceOf(address(this));
 
-        // If we have loan tokens, we are repaying a loan.
-        if (loanTokenBalance > 0) {
-            morpho.repay(params, loanTokenBalance, 0, onBehalf, "");
-            return;
-        }
+        checkReceived(collateralTokenBalance, amount);
 
-        // If we have collateral tokens, we are supplying collateral.
-        if (collateralTokenBalance > 0) {
-            morpho.supplyCollateral(params, collateralTokenBalance, onBehalf, "");
+        morpho.supplyCollateral(loadParams(), collateralTokenBalance, recipient, "");
 
-            // borrow and send to rollup?
+        // Future extension:
+        // borrow some amount of loanToken
+        // and send it to the rollup
 
-            return;
-        }
-
-        revert("No tokens received");
+        return true;
     }
 }

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+type Id is bytes32;
+
+struct MarketParams {
+    address loanToken;
+    address collateralToken;
+    address oracle;
+    address irm;
+    uint256 lltv;
+}
+
+/// @dev Warning: For `feeRecipient`, `supplyShares` does not contain the accrued shares since the last interest
+/// accrual.
+struct Position {
+    uint256 supplyShares;
+    uint128 borrowShares;
+    uint128 collateral;
+}
+
+/// @dev Warning: `totalSupplyAssets` does not contain the accrued interest since the last interest accrual.
+/// @dev Warning: `totalBorrowAssets` does not contain the accrued interest since the last interest accrual.
+/// @dev Warning: `totalSupplyShares` does not contain the additional shares accrued by `feeRecipient` since the last
+/// interest accrual.
+struct Market {
+    uint128 totalSupplyAssets;
+    uint128 totalSupplyShares;
+    uint128 totalBorrowAssets;
+    uint128 totalBorrowShares;
+    uint128 lastUpdate;
+    uint128 fee;
+}
+
+struct Authorization {
+    address authorizer;
+    address authorized;
+    bool isAuthorized;
+    uint256 nonce;
+    uint256 deadline;
+}
+
+struct Signature {
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+}
+
+/// @dev This interface is used for factorizing IMorphoStaticTyping and IMorpho.
+/// @dev Consider using the IMorpho interface instead of this one.
+interface IMorphoBase {
+    /// @notice The EIP-712 domain separator.
+    /// @dev Warning: Every EIP-712 signed message based on this domain separator can be reused on another chain sharing
+    /// the same chain id because the domain separator would be the same.
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    /// @notice The owner of the contract.
+    /// @dev It has the power to change the owner.
+    /// @dev It has the power to set fees on markets and set the fee recipient.
+    /// @dev It has the power to enable but not disable IRMs and LLTVs.
+    function owner() external view returns (address);
+
+    /// @notice The fee recipient of all markets.
+    /// @dev The recipient receives the fees of a given market through a supply position on that market.
+    function feeRecipient() external view returns (address);
+
+    /// @notice Whether the `irm` is enabled.
+    function isIrmEnabled(address irm) external view returns (bool);
+
+    /// @notice Whether the `lltv` is enabled.
+    function isLltvEnabled(uint256 lltv) external view returns (bool);
+
+    /// @notice Whether `authorized` is authorized to modify `authorizer`'s position on all markets.
+    /// @dev Anyone is authorized to modify their own positions, regardless of this variable.
+    function isAuthorized(address authorizer, address authorized) external view returns (bool);
+
+    /// @notice The `authorizer`'s current nonce. Used to prevent replay attacks with EIP-712 signatures.
+    function nonce(address authorizer) external view returns (uint256);
+
+    /// @notice Sets `newOwner` as `owner` of the contract.
+    /// @dev Warning: No two-step transfer ownership.
+    /// @dev Warning: The owner can be set to the zero address.
+    function setOwner(address newOwner) external;
+
+    /// @notice Enables `irm` as a possible IRM for market creation.
+    /// @dev Warning: It is not possible to disable an IRM.
+    function enableIrm(address irm) external;
+
+    /// @notice Enables `lltv` as a possible LLTV for market creation.
+    /// @dev Warning: It is not possible to disable a LLTV.
+    function enableLltv(uint256 lltv) external;
+
+    /// @notice Sets the `newFee` for the given market `marketParams`.
+    /// @param newFee The new fee, scaled by WAD.
+    /// @dev Warning: The recipient can be the zero address.
+    function setFee(MarketParams memory marketParams, uint256 newFee) external;
+
+    /// @notice Sets `newFeeRecipient` as `feeRecipient` of the fee.
+    /// @dev Warning: If the fee recipient is set to the zero address, fees will accrue there and will be lost.
+    /// @dev Modifying the fee recipient will allow the new recipient to claim any pending fees not yet accrued. To
+    /// ensure that the current recipient receives all due fees, accrue interest manually prior to making any changes.
+    function setFeeRecipient(address newFeeRecipient) external;
+
+    /// @notice Creates the market `marketParams`.
+    /// @dev Here is the list of assumptions on the market's dependencies (tokens, IRM and oracle) that guarantees
+    /// Morpho behaves as expected:
+    /// - The token should be ERC-20 compliant, except that it can omit return values on `transfer` and `transferFrom`.
+    /// - The token balance of Morpho should only decrease on `transfer` and `transferFrom`. In particular, tokens with
+    /// burn functions are not supported.
+    /// - The token should not re-enter Morpho on `transfer` nor `transferFrom`.
+    /// - The token balance of the sender (resp. receiver) should decrease (resp. increase) by exactly the given amount
+    /// on `transfer` and `transferFrom`. In particular, tokens with fees on transfer are not supported.
+    /// - The IRM should not re-enter Morpho.
+    /// - The oracle should return a price with the correct scaling.
+    /// @dev Here is a list of properties on the market's dependencies that could break Morpho's liveness properties
+    /// (funds could get stuck):
+    /// - The token can revert on `transfer` and `transferFrom` for a reason other than an approval or balance issue.
+    /// - A very high amount of assets (~1e35) supplied or borrowed can make the computation of `toSharesUp` and
+    /// `toSharesDown` overflow.
+    /// - The IRM can revert on `borrowRate`.
+    /// - A very high borrow rate returned by the IRM can make the computation of `interest` in `_accrueInterest`
+    /// overflow.
+    /// - The oracle can revert on `price`. Note that this can be used to prevent `borrow`, `withdrawCollateral` and
+    /// `liquidate` from being used under certain market conditions.
+    /// - A very high price returned by the oracle can make the computation of `maxBorrow` in `_isHealthy` overflow, or
+    /// the computation of `assetsRepaid` in `liquidate` overflow.
+    /// @dev The borrow share price of a market with less than 1e4 assets borrowed can be decreased by manipulations, to
+    /// the point where `totalBorrowShares` is very large and borrowing overflows.
+    function createMarket(MarketParams memory marketParams) external;
+
+    /// @notice Supplies `assets` or `shares` on behalf of `onBehalf`, optionally calling back the caller's
+    /// `onMorphoSupply` function with the given `data`.
+    /// @dev Either `assets` or `shares` should be zero. Most use cases should rely on `assets` as an input so the
+    /// caller is guaranteed to have `assets` tokens pulled from their balance, but the possibility to mint a specific
+    /// amount of shares is given for full compatibility and precision.
+    /// @dev Supplying a large amount can revert for overflow.
+    /// @dev Supplying an amount of shares may lead to supply more or fewer assets than expected due to slippage.
+    /// Consider using the `assets` parameter to avoid this.
+    /// @param marketParams The market to supply assets to.
+    /// @param assets The amount of assets to supply.
+    /// @param shares The amount of shares to mint.
+    /// @param onBehalf The address that will own the increased supply position.
+    /// @param data Arbitrary data to pass to the `onMorphoSupply` callback. Pass empty data if not needed.
+    /// @return assetsSupplied The amount of assets supplied.
+    /// @return sharesSupplied The amount of shares minted.
+    function supply(
+        MarketParams memory marketParams,
+        uint256 assets,
+        uint256 shares,
+        address onBehalf,
+        bytes memory data
+    ) external returns (uint256 assetsSupplied, uint256 sharesSupplied);
+
+    /// @notice Withdraws `assets` or `shares` on behalf of `onBehalf` and sends the assets to `receiver`.
+    /// @dev Either `assets` or `shares` should be zero. To withdraw max, pass the `shares`'s balance of `onBehalf`.
+    /// @dev `msg.sender` must be authorized to manage `onBehalf`'s positions.
+    /// @dev Withdrawing an amount corresponding to more shares than supplied will revert for underflow.
+    /// @dev It is advised to use the `shares` input when withdrawing the full position to avoid reverts due to
+    /// conversion roundings between shares and assets.
+    /// @param marketParams The market to withdraw assets from.
+    /// @param assets The amount of assets to withdraw.
+    /// @param shares The amount of shares to burn.
+    /// @param onBehalf The address of the owner of the supply position.
+    /// @param receiver The address that will receive the withdrawn assets.
+    /// @return assetsWithdrawn The amount of assets withdrawn.
+    /// @return sharesWithdrawn The amount of shares burned.
+    function withdraw(
+        MarketParams memory marketParams,
+        uint256 assets,
+        uint256 shares,
+        address onBehalf,
+        address receiver
+    ) external returns (uint256 assetsWithdrawn, uint256 sharesWithdrawn);
+
+    /// @notice Borrows `assets` or `shares` on behalf of `onBehalf` and sends the assets to `receiver`.
+    /// @dev Either `assets` or `shares` should be zero. Most use cases should rely on `assets` as an input so the
+    /// caller is guaranteed to borrow `assets` of tokens, but the possibility to mint a specific amount of shares is
+    /// given for full compatibility and precision.
+    /// @dev `msg.sender` must be authorized to manage `onBehalf`'s positions.
+    /// @dev Borrowing a large amount can revert for overflow.
+    /// @dev Borrowing an amount of shares may lead to borrow fewer assets than expected due to slippage.
+    /// Consider using the `assets` parameter to avoid this.
+    /// @param marketParams The market to borrow assets from.
+    /// @param assets The amount of assets to borrow.
+    /// @param shares The amount of shares to mint.
+    /// @param onBehalf The address that will own the increased borrow position.
+    /// @param receiver The address that will receive the borrowed assets.
+    /// @return assetsBorrowed The amount of assets borrowed.
+    /// @return sharesBorrowed The amount of shares minted.
+    function borrow(
+        MarketParams memory marketParams,
+        uint256 assets,
+        uint256 shares,
+        address onBehalf,
+        address receiver
+    ) external returns (uint256 assetsBorrowed, uint256 sharesBorrowed);
+
+    /// @notice Repays `assets` or `shares` on behalf of `onBehalf`, optionally calling back the caller's
+    /// `onMorphoReplay` function with the given `data`.
+    /// @dev Either `assets` or `shares` should be zero. To repay max, pass the `shares`'s balance of `onBehalf`.
+    /// @dev Repaying an amount corresponding to more shares than borrowed will revert for underflow.
+    /// @dev It is advised to use the `shares` input when repaying the full position to avoid reverts due to conversion
+    /// roundings between shares and assets.
+    /// @dev An attacker can front-run a repay with a small repay making the transaction revert for underflow.
+    /// @param marketParams The market to repay assets to.
+    /// @param assets The amount of assets to repay.
+    /// @param shares The amount of shares to burn.
+    /// @param onBehalf The address of the owner of the debt position.
+    /// @param data Arbitrary data to pass to the `onMorphoRepay` callback. Pass empty data if not needed.
+    /// @return assetsRepaid The amount of assets repaid.
+    /// @return sharesRepaid The amount of shares burned.
+    function repay(
+        MarketParams memory marketParams,
+        uint256 assets,
+        uint256 shares,
+        address onBehalf,
+        bytes memory data
+    ) external returns (uint256 assetsRepaid, uint256 sharesRepaid);
+
+    /// @notice Supplies `assets` of collateral on behalf of `onBehalf`, optionally calling back the caller's
+    /// `onMorphoSupplyCollateral` function with the given `data`.
+    /// @dev Interest are not accrued since it's not required and it saves gas.
+    /// @dev Supplying a large amount can revert for overflow.
+    /// @param marketParams The market to supply collateral to.
+    /// @param assets The amount of collateral to supply.
+    /// @param onBehalf The address that will own the increased collateral position.
+    /// @param data Arbitrary data to pass to the `onMorphoSupplyCollateral` callback. Pass empty data if not needed.
+    function supplyCollateral(MarketParams memory marketParams, uint256 assets, address onBehalf, bytes memory data)
+        external;
+
+    /// @notice Withdraws `assets` of collateral on behalf of `onBehalf` and sends the assets to `receiver`.
+    /// @dev `msg.sender` must be authorized to manage `onBehalf`'s positions.
+    /// @dev Withdrawing an amount corresponding to more collateral than supplied will revert for underflow.
+    /// @param marketParams The market to withdraw collateral from.
+    /// @param assets The amount of collateral to withdraw.
+    /// @param onBehalf The address of the owner of the collateral position.
+    /// @param receiver The address that will receive the collateral assets.
+    function withdrawCollateral(MarketParams memory marketParams, uint256 assets, address onBehalf, address receiver)
+        external;
+
+    /// @notice Liquidates the given `repaidShares` of debt asset or seize the given `seizedAssets` of collateral on the
+    /// given market `marketParams` of the given `borrower`'s position, optionally calling back the caller's
+    /// `onMorphoLiquidate` function with the given `data`.
+    /// @dev Either `seizedAssets` or `repaidShares` should be zero.
+    /// @dev Seizing more than the collateral balance will underflow and revert without any error message.
+    /// @dev Repaying more than the borrow balance will underflow and revert without any error message.
+    /// @dev An attacker can front-run a liquidation with a small repay making the transaction revert for underflow.
+    /// @param marketParams The market of the position.
+    /// @param borrower The owner of the position.
+    /// @param seizedAssets The amount of collateral to seize.
+    /// @param repaidShares The amount of shares to repay.
+    /// @param data Arbitrary data to pass to the `onMorphoLiquidate` callback. Pass empty data if not needed.
+    /// @return The amount of assets seized.
+    /// @return The amount of assets repaid.
+    function liquidate(
+        MarketParams memory marketParams,
+        address borrower,
+        uint256 seizedAssets,
+        uint256 repaidShares,
+        bytes memory data
+    ) external returns (uint256, uint256);
+
+    /// @notice Executes a flash loan.
+    /// @dev Flash loans have access to the whole balance of the contract (the liquidity and deposited collateral of all
+    /// markets combined, plus donations).
+    /// @dev Warning: Not ERC-3156 compliant but compatibility is easily reached:
+    /// - `flashFee` is zero.
+    /// - `maxFlashLoan` is the token's balance of this contract.
+    /// - The receiver of `assets` is the caller.
+    /// @param token The token to flash loan.
+    /// @param assets The amount of assets to flash loan.
+    /// @param data Arbitrary data to pass to the `onMorphoFlashLoan` callback.
+    function flashLoan(address token, uint256 assets, bytes calldata data) external;
+
+    /// @notice Sets the authorization for `authorized` to manage `msg.sender`'s positions.
+    /// @param authorized The authorized address.
+    /// @param newIsAuthorized The new authorization status.
+    function setAuthorization(address authorized, bool newIsAuthorized) external;
+
+    /// @notice Sets the authorization for `authorization.authorized` to manage `authorization.authorizer`'s positions.
+    /// @dev Warning: Reverts if the signature has already been submitted.
+    /// @dev The signature is malleable, but it has no impact on the security here.
+    /// @dev The nonce is passed as argument to be able to revert with a different error message.
+    /// @param authorization The `Authorization` struct.
+    /// @param signature The signature.
+    function setAuthorizationWithSig(Authorization calldata authorization, Signature calldata signature) external;
+
+    /// @notice Accrues interest for the given market `marketParams`.
+    function accrueInterest(MarketParams memory marketParams) external;
+
+    /// @notice Returns the data stored on the different `slots`.
+    function extSloads(bytes32[] memory slots) external view returns (bytes32[] memory);
+}
+
+/// @dev This interface is inherited by Morpho so that function signatures are checked by the compiler.
+/// @dev Consider using the IMorpho interface instead of this one.
+interface IMorphoStaticTyping is IMorphoBase {
+    /// @notice The state of the position of `user` on the market corresponding to `id`.
+    /// @dev Warning: For `feeRecipient`, `supplyShares` does not contain the accrued shares since the last interest
+    /// accrual.
+    function position(Id id, address user)
+        external
+        view
+        returns (uint256 supplyShares, uint128 borrowShares, uint128 collateral);
+
+    /// @notice The state of the market corresponding to `id`.
+    /// @dev Warning: `totalSupplyAssets` does not contain the accrued interest since the last interest accrual.
+    /// @dev Warning: `totalBorrowAssets` does not contain the accrued interest since the last interest accrual.
+    /// @dev Warning: `totalSupplyShares` does not contain the accrued shares by `feeRecipient` since the last interest
+    /// accrual.
+    function market(Id id)
+        external
+        view
+        returns (
+            uint128 totalSupplyAssets,
+            uint128 totalSupplyShares,
+            uint128 totalBorrowAssets,
+            uint128 totalBorrowShares,
+            uint128 lastUpdate,
+            uint128 fee
+        );
+
+    /// @notice The market params corresponding to `id`.
+    /// @dev This mapping is not used in Morpho. It is there to enable reducing the cost associated to calldata on layer
+    /// 2s by creating a wrapper contract with functions that take `id` as input instead of `marketParams`.
+    function idToMarketParams(Id id)
+        external
+        view
+        returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv);
+}
+
+/// @title IMorpho
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @dev Use this interface for Morpho to have access to all the functions with the appropriate function signatures.
+interface IMorpho is IMorphoBase {
+    /// @notice The state of the position of `user` on the market corresponding to `id`.
+    /// @dev Warning: For `feeRecipient`, `p.supplyShares` does not contain the accrued shares since the last interest
+    /// accrual.
+    function position(Id id, address user) external view returns (Position memory p);
+
+    /// @notice The state of the market corresponding to `id`.
+    /// @dev Warning: `m.totalSupplyAssets` does not contain the accrued interest since the last interest accrual.
+    /// @dev Warning: `m.totalBorrowAssets` does not contain the accrued interest since the last interest accrual.
+    /// @dev Warning: `m.totalSupplyShares` does not contain the accrued shares by `feeRecipient` since the last
+    /// interest accrual.
+    function market(Id id) external view returns (Market memory m);
+
+    /// @notice The market params corresponding to `id`.
+    /// @dev This mapping is not used in Morpho. It is there to enable reducing the cost associated to calldata on layer
+    /// 2s by creating a wrapper contract with functions that take `id` as input instead of `marketParams`.
+    function idToMarketParams(Id id) external view returns (MarketParams memory);
+}


### PR DESCRIPTION
 Adds an example using Morpho to do same-block loan supply and repayments from Signet to Ethereum