### PR TITLE
chore: move L2 constants that do not change by network to a separate file

### DIFF
--- a/src/chains/L2.sol
+++ b/src/chains/L2.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {RollupOrders} from "zenith/src/orders/RollupOrders.sol";
+import {RollupPassage} from "zenith/src/passage/RollupPassage.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+abstract contract RollupConstants {
+    /// @notice The Rollup Passage contract for the Parmigiana testnet.
+    RollupPassage constant PASSAGE = RollupPassage(payable(0x0000000000007369676E65742D70617373616765));
+
+    /// @notice The Rollup Orders contract for the Parmigiana testnet.
+    RollupOrders constant ORDERS = RollupOrders(0x000000000000007369676E65742D6f7264657273);
+
+    /// @notice WETH token address for the Parmigiana testnet.
+    IERC20 constant WETH = IERC20(0x0000000000000000007369676e65742d77657468);
+    /// @notice WBTC token address for the Parmigiana testnet.
+    IERC20 constant WBTC = IERC20(0x0000000000000000007369676e65742D77627463);
+    /// @notice WUSD token address for the Parmigiana testnet.
+    IERC20 constant WUSD = IERC20(0x0000000000000000007369676e65742D77757364);
+}

--- a/src/chains/Parmigiana.sol
+++ b/src/chains/Parmigiana.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {RollupOrders} from "zenith/src/orders/RollupOrders.sol";
-import {RollupPassage} from "zenith/src/passage/RollupPassage.sol";
 import {HostOrders} from "zenith/src/orders/HostOrders.sol";
 import {Passage} from "zenith/src/passage/Passage.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 /// @title ParmigianaConstants
 /// @author init4
@@ -24,12 +21,6 @@ library ParmigianaConstants {
     /// @notice The HostOrders contract for the Parmigiana testnet host chain.
     HostOrders constant HOST_ORDERS = HostOrders(0x96f44ddc3Bc8892371305531F1a6d8ca2331fE6C);
 
-    /// @notice The Rollup Passage contract for the Parmigiana testnet.
-    RollupPassage constant ROLLUP_PASSAGE = RollupPassage(payable(0x0000000000007369676E65742D70617373616765));
-
-    /// @notice The Rollup Orders contract for the Parmigiana testnet.
-    RollupOrders constant ROLLUP_ORDERS = RollupOrders(0x000000000000007369676E65742D6f7264657273);
-
     /// USDC token for the Parmigiana testnet host chain.
     address constant HOST_USDC = 0x65Fb255585458De1F9A246b476aa8d5C5516F6fd;
     /// USDT token for the Parmigiana testnet host chain.
@@ -38,11 +29,4 @@ library ParmigianaConstants {
     address constant HOST_WBTC = 0xfb29F7d7a4CE607D6038d44150315e5F69BEa08A;
     /// WETH token for the Parmigiana testnet host chain.
     address constant HOST_WETH = 0xD1278f17e86071f1E658B656084c65b7FD3c90eF;
-
-    /// @notice WETH token address for the Parmigiana testnet.
-    IERC20 constant WETH = IERC20(0x0000000000000000007369676e65742d77657468);
-    /// @notice WBTC token address for the Parmigiana testnet.
-    IERC20 constant WBTC = IERC20(0x0000000000000000007369676e65742D77627463);
-    /// @notice WUSD token address for the Parmigiana testnet.
-    IERC20 constant WUSD = IERC20(0x0000000000000000007369676e65742D77757364);
 }

--- a/src/l1/Signet.sol
+++ b/src/l1/Signet.sol
@@ -55,10 +55,6 @@ abstract contract SignetL1 {
             WBTC = IERC20(ParmigianaConstants.HOST_WBTC);
             USDC = IERC20(ParmigianaConstants.HOST_USDC);
             USDT = IERC20(ParmigianaConstants.HOST_USDT);
-
-            RU_WUSD = address(ParmigianaConstants.WUSD);
-            RU_WBTC = address(ParmigianaConstants.WBTC);
-            RU_WETH = address(ParmigianaConstants.WETH);
         } else {
             revert UnsupportedChain(block.chainid);
         }

--- a/src/l2/Signet.sol
+++ b/src/l2/Signet.sol
@@ -2,13 +2,12 @@
 pragma solidity ^0.8.13;
 
 import {RollupOrders} from "zenith/src/orders/RollupOrders.sol";
-import {RollupPassage} from "zenith/src/passage/RollupPassage.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
+import {RollupConstants} from "../chains/L2.sol";
 import {ParmigianaConstants} from "../chains/Parmigiana.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
-contract SignetL2 {
+contract SignetL2 is RollupConstants {
     /// @notice Sentinal value for the native asset in order inputs/outputs
     address constant NATIVE_ASSET = address(0);
 
@@ -18,20 +17,8 @@ contract SignetL2 {
     /// @notice The chain ID of the host network.
     uint32 internal immutable HOST_CHAIN_ID;
 
-    /// @notice The Rollup Passage contract.
-    RollupPassage internal immutable PASSAGE;
-    /// @notice The Rollup Orders contract.
-    RollupOrders internal immutable ORDERS;
-
     /// @notice The address of the Rollup Passage on the host network.
     address immutable HOST_PASSAGE;
-
-    /// @notice The WETH token address.
-    IERC20 internal immutable WETH;
-    /// @notice The WBTC token address.
-    IERC20 internal immutable WBTC;
-    /// @notice The WUSD token address.
-    IERC20 internal immutable WUSD;
 
     /// @notice The USDC token address on the host network.
     address internal immutable HOST_USDC;
@@ -51,13 +38,6 @@ contract SignetL2 {
             HOST_CHAIN_ID = ParmigianaConstants.HOST_CHAIN_ID;
 
             HOST_PASSAGE = address(ParmigianaConstants.HOST_PASSAGE);
-
-            PASSAGE = ParmigianaConstants.ROLLUP_PASSAGE;
-            ORDERS = ParmigianaConstants.ROLLUP_ORDERS;
-
-            WETH = ParmigianaConstants.WETH;
-            WBTC = ParmigianaConstants.WBTC;
-            WUSD = ParmigianaConstants.WUSD;
 
             HOST_USDC = ParmigianaConstants.HOST_USDC;
             HOST_USDT = ParmigianaConstants.HOST_USDT;
@@ -91,12 +71,15 @@ contract SignetL2 {
         input.amount = amount;
     }
 
-    function makeWethInput(uint256 amount) internal view returns (RollupOrders.Input memory input) {
+    /// @notice Creates an Input struct for the WETH token.
+    /// @param amount The amount of WETH.
+    /// @return input The created Input struct for WETH.
+    function makeWethInput(uint256 amount) internal pure returns (RollupOrders.Input memory input) {
         input.token = address(WETH);
         input.amount = amount;
     }
 
-    function makeWbtcInput(uint256 amount) internal view returns (RollupOrders.Input memory input) {
+    function makeWbtcInput(uint256 amount) internal pure returns (RollupOrders.Input memory input) {
         input.token = address(WBTC);
         input.amount = amount;
     }


### PR DESCRIPTION
Creates a new file to hold constants that are unchanged on all Signet rollup chains