### PR TITLE
Fix broken README links to example contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,20 @@ are effectively MEV, you can do some really interesting things with them. Like
 
 ## Orders Examples
 
-- [`SignetStd.sol`](./src/SignetStd.sol) - A simple contract that
-  auto-configures Signet system parameters, based on the chain id.
-- [`Flash.sol`](./src/examples/Flash.sol) - Allows your contract to flash borrow
+- [`Flash.sol`](./src/l2/examples/Flash.sol) - Allows your contract to flash borrow
   any asset (provided some searcher will provide it). Flash loans work by
   having an input and output of the same asset. The Output is then used as the
   Input to its own Order. This is pretty neat 🎀
-- [`GetOut.sol`](./src/examples/GetOut.sol) - A shortcut contract for
+- [`GetOut.sol`](./src/l2/examples/GetOut.sol) - A shortcut contract for
   exiting Signet (by offering searchers a 50 bps fee).
-- [`PayMe.sol`](./src/examples/PayMe.sol) - Payment gating for smart contracts,
+- [`PayMe.sol`](./src/l2/examples/PayMe.sol) - Payment gating for smart contracts,
   using a Signet Order with no inputs. These ensures that contract execution is
   invalid unless SOMEONE has filled the Order. Unlike traditional payment gates
   that check `msg.value`, this does NOT require the calling contract to manage
   cash flow. Instead _any third party_ can fill the order. The calling contract
   can be blind to the payment. This greatly simplifies contract logic required
   to implement payment gates.
-- [`PayYou.sol`](./src/examples/PayYou.sol) - The opposite of payment gating,
+- [`PayYou.sol`](./src/l2/examples/PayYou.sol) - The opposite of payment gating,
   this allows a contract to generate MEV by offering a Signet Order with no
   outputs. This payment becomes a bounty for calling the contract, and
   functions as an incentivized scheduling system.


### PR DESCRIPTION
## Summary
- Removed stale `SignetStd.sol` entry (file no longer exists in repo)
- Fixed 4 example contract links: `./src/examples/` → `./src/l2/examples/` for Flash, GetOut, PayMe, and PayYou

## Test plan
- [x] Verify all README links resolve correctly on GitHub