### PR TITLE
fix: typo HosyMorphoBorrow -> HostMorphoBorrow

### DIFF
--- a/src/apps/Morpho.sol
+++ b/src/apps/Morpho.sol
@@ -237,7 +237,7 @@ contract HostMorphoSupply is HostMorphoUser {
     }
 }
 
-contract HosyMorphoBorrow is HostMorphoUser {
+contract HostMorphoBorrow is HostMorphoUser {
     constructor(IMorpho _morpho, MarketParams memory _params) HostMorphoUser(_morpho, _params) {}
 
     // This function


### PR DESCRIPTION
Fixes a typo in `src/apps/Morpho.sol` — `HosyMorphoBorrow` should be `HostMorphoBorrow`.