### PR TITLE
feat: add Gouda testnet support

### DIFF
--- a/src/chains/Gouda.sol
+++ b/src/chains/Gouda.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {HostOrders} from "zenith/src/orders/HostOrders.sol";
+import {Passage} from "zenith/src/passage/Passage.sol";
+
+/// @title GoudaConstants
+/// @author init4
+/// @notice Constants for the Gouda testnet.
+/// @dev Gouda runs on the Parmigiana host chain, so HOST_CHAIN_ID matches
+///      Parmigiana's. Rollup chain ID and on-host contract deployments are
+///      gouda-specific. Used by `SignetL2` when block.chainid == ROLLUP_CHAIN_ID.
+library GoudaConstants {
+    /// @notice The Gouda host chain ID (shared with Parmigiana).
+    uint32 constant HOST_CHAIN_ID = 3151908;
+    /// @notice The Gouda Rollup chain ID.
+    uint32 constant ROLLUP_CHAIN_ID = 792669;
+
+    /// @notice The Passage contract for the Gouda host chain.
+    Passage constant HOST_PASSAGE = Passage(payable(0x57348c54e3F89097579dFcD4F5d2700ca2EB1906));
+
+    /// @notice The HostOrders contract for the Gouda host chain.
+    HostOrders constant HOST_ORDERS = HostOrders(0x5C5cd1F1c35227b14F6A94c6e05347403F4C963E);
+
+    /// USDC token for the Gouda host chain.
+    address constant HOST_USDC = 0x6A27cc6968b1d08cd04a656075cc25905156827E;
+    /// USDT token for the Gouda host chain.
+    address constant HOST_USDT = 0x3Aad2B8D721bB2F7F79356515D15AAd3F8d6a32d;
+    /// WBTC token for the Gouda host chain.
+    address constant HOST_WBTC = 0x260fDcb6e6e2c1C5f96647ee0FaE34E7E92e6f28;
+    /// WETH token for the Gouda host chain.
+    address constant HOST_WETH = 0xD1278f17e86071f1E658B656084c65b7FD3c90eF;
+}

--- a/src/l2/Signet.sol
+++ b/src/l2/Signet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {RollupOrders} from "zenith/src/orders/RollupOrders.sol";
 
 import {RollupConstants} from "../chains/L2.sol";
+import {GoudaConstants} from "../chains/Gouda.sol";
 import {ParmigianaConstants} from "../chains/Parmigiana.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
@@ -43,6 +44,15 @@ contract SignetL2 is RollupConstants {
             HOST_USDT = ParmigianaConstants.HOST_USDT;
             HOST_WBTC = ParmigianaConstants.HOST_WBTC;
             HOST_WETH = ParmigianaConstants.HOST_WETH;
+        } else if (block.chainid == GoudaConstants.ROLLUP_CHAIN_ID) {
+            HOST_CHAIN_ID = GoudaConstants.HOST_CHAIN_ID;
+
+            HOST_PASSAGE = address(GoudaConstants.HOST_PASSAGE);
+
+            HOST_USDC = GoudaConstants.HOST_USDC;
+            HOST_USDT = GoudaConstants.HOST_USDT;
+            HOST_WBTC = GoudaConstants.HOST_WBTC;
+            HOST_WETH = GoudaConstants.HOST_WETH;
         } else {
             revert UnsupportedChain(block.chainid);
         }


### PR DESCRIPTION
## Summary
- Adds \`chains/Gouda.sol\` with rollup chain ID 792669, deployed Passage/Orders addresses on the Gouda host (`0x57348c54e3F89097579dFcD4F5d2700ca2EB1906` / `0x5C5cd1F1c35227b14F6A94c6e05347403F4C963E`), and Gouda host token addresses. \`HOST_CHAIN_ID\` matches Parmigiana's (3151908) — Gouda runs on the Parmigiana host chain.
- Adds a Gouda \`else if\` branch in \`SignetL2\`'s constructor, mirroring the existing Parmigiana pattern, so contracts inheriting \`Flash\`/\`PayMe\`/etc compile and deploy on Gouda.

## Test plan
- [x] \`forge build\` clean
- [x] \`FlashProbe\` (from signet-e2e/contracts) deploys to Gouda RU at \`0x28436307Eb88e4b571EbD866435dFC634CD345C9\` against this branch — previously reverted with \`UnsupportedChain(792669)\`.

## Related
- init4tech/signet-sdk#236 (adds \`signet_constants::gouda\`)
- init4tech/node-components#144 (adds gouda.genesis.json)
- init4tech/bin-base#149 (KnownChains::Gouda)

🤖 Generated with [Claude Code](https://claude.com/claude-code)